### PR TITLE
FB-14-feat 단어 퀴즈 유저 레벨에 맞게 랜덤 출력

### DIFF
--- a/src/main/generated/mono/focusider/domain/quiz/domain/QQuiz.java
+++ b/src/main/generated/mono/focusider/domain/quiz/domain/QQuiz.java
@@ -24,6 +24,8 @@ public class QQuiz extends EntityPathBase<Quiz> {
 
     public final mono.focusider.global.domain.QBaseTimeEntity _super = new mono.focusider.global.domain.QBaseTimeEntity(this);
 
+    public final ListPath<Choice, QChoice> choices = this.<Choice, QChoice>createList("choices", Choice.class, QChoice.class, PathInits.DIRECT2);
+
     public final QCommentary commentary;
 
     public final StringPath content = createString("content");
@@ -37,6 +39,8 @@ public class QQuiz extends EntityPathBase<Quiz> {
     public final DateTimePath<java.time.LocalDateTime> lastModifiedAt = _super.lastModifiedAt;
 
     public final NumberPath<Integer> level = createNumber("level", Integer.class);
+
+    public final ListPath<QuizAttempt, QQuizAttempt> quizAttempts = this.<QuizAttempt, QQuizAttempt>createList("quizAttempts", QuizAttempt.class, QQuizAttempt.class, PathInits.DIRECT2);
 
     public final StringPath title = createString("title");
 

--- a/src/main/generated/mono/focusider/domain/quiz/domain/QQuizAttempt.java
+++ b/src/main/generated/mono/focusider/domain/quiz/domain/QQuizAttempt.java
@@ -32,6 +32,8 @@ public class QQuizAttempt extends EntityPathBase<QuizAttempt> {
     //inherited
     public final DateTimePath<java.time.LocalDateTime> lastModifiedAt = _super.lastModifiedAt;
 
+    public final mono.focusider.domain.member.domain.QMember member;
+
     public final QQuiz quiz;
 
     public final EnumPath<mono.focusider.domain.quiz.type.QuizStatusType> quizStatusType = createEnum("quizStatusType", mono.focusider.domain.quiz.type.QuizStatusType.class);
@@ -54,6 +56,7 @@ public class QQuizAttempt extends EntityPathBase<QuizAttempt> {
 
     public QQuizAttempt(Class<? extends QuizAttempt> type, PathMetadata metadata, PathInits inits) {
         super(type, metadata, inits);
+        this.member = inits.isInitialized("member") ? new mono.focusider.domain.member.domain.QMember(forProperty("member"), inits.get("member")) : null;
         this.quiz = inits.isInitialized("quiz") ? new QQuiz(forProperty("quiz"), inits.get("quiz")) : null;
     }
 

--- a/src/main/java/mono/focusider/application/quiz/controller/QuizController.java
+++ b/src/main/java/mono/focusider/application/quiz/controller/QuizController.java
@@ -1,16 +1,20 @@
 package mono.focusider.application.quiz.controller;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import mono.focusider.domain.quiz.dto.info.QuizSetInfo;
+import mono.focusider.domain.quiz.dto.res.QuizInfo;
 import mono.focusider.domain.quiz.service.QuizService;
+import mono.focusider.global.annotation.MemberInfo;
+import mono.focusider.global.aspect.member.MemberInfoParam;
 import mono.focusider.global.domain.SuccessResponse;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @Slf4j
 @RestController
@@ -19,6 +23,16 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 public class QuizController {
     private final QuizService quizService;
+
+    @Operation(summary = "레벨에 맞는 퀴즈 출력", description = "퀴즈 출력", responses = {
+            @ApiResponse(responseCode = "200", content = @Content(schema = @Schema(implementation = QuizInfo.class))),
+            @ApiResponse(responseCode = "500", description = "에러")
+    })
+    @GetMapping
+    public ResponseEntity<SuccessResponse<?>> getQuiz(@MemberInfo MemberInfoParam memberInfoParam) {
+        QuizInfo result = quizService.findQuizByLevel(memberInfoParam);
+        return SuccessResponse.ok(result);
+    }
 
     @PostMapping("/make")
     public ResponseEntity<SuccessResponse<?>> makeQuiz(@RequestBody QuizSetInfo quizSetInfo) {

--- a/src/main/java/mono/focusider/domain/quiz/domain/Quiz.java
+++ b/src/main/java/mono/focusider/domain/quiz/domain/Quiz.java
@@ -4,6 +4,9 @@ import jakarta.persistence.*;
 import lombok.*;
 import mono.focusider.global.domain.BaseTimeEntity;
 
+import java.util.ArrayList;
+import java.util.List;
+
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder(access = AccessLevel.PRIVATE)
@@ -27,6 +30,14 @@ public class Quiz extends BaseTimeEntity {
     @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "commentary_id")
     private Commentary commentary;
+
+    @OneToMany(mappedBy = "quiz", cascade = CascadeType.ALL, orphanRemoval = true)
+    @Builder.Default
+    private List<Choice> choices = new ArrayList<>();
+
+    @OneToMany(mappedBy = "quiz", cascade = CascadeType.ALL, orphanRemoval = true)
+    @Builder.Default
+    private List<QuizAttempt> quizAttempts = new ArrayList<>();
 
     public static Quiz of(String title, String content, Integer level, Commentary commentary) {
         return Quiz

--- a/src/main/java/mono/focusider/domain/quiz/domain/QuizAttempt.java
+++ b/src/main/java/mono/focusider/domain/quiz/domain/QuizAttempt.java
@@ -2,6 +2,7 @@ package mono.focusider.domain.quiz.domain;
 
 import jakarta.persistence.*;
 import lombok.*;
+import mono.focusider.domain.member.domain.Member;
 import mono.focusider.domain.quiz.type.QuizStatusType;
 import mono.focusider.domain.quiz.type.converter.QuizStatusTypeConverter;
 import mono.focusider.global.domain.BaseTimeEntity;
@@ -19,6 +20,10 @@ public class QuizAttempt extends BaseTimeEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "quiz_id", nullable = false)
     private Quiz quiz;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id", nullable = false)
+    private Member member;
 
     @Column(name = "correct", nullable = false)
     @Convert(converter = QuizStatusTypeConverter.class)

--- a/src/main/java/mono/focusider/domain/quiz/dto/info/ChoiceInfo.java
+++ b/src/main/java/mono/focusider/domain/quiz/dto/info/ChoiceInfo.java
@@ -1,7 +1,19 @@
 package mono.focusider.domain.quiz.dto.info;
 
+import lombok.AccessLevel;
+import lombok.Builder;
+import mono.focusider.domain.quiz.domain.Choice;
+
+@Builder(access = AccessLevel.PRIVATE)
 public record ChoiceInfo(
-        String content,
-        Boolean isAnswer
+        Long id,
+        String content
 ) {
+    public static ChoiceInfo of(Choice choice) {
+        return ChoiceInfo
+                .builder()
+                .id(choice.getId())
+                .content(choice.getContent())
+                .build();
+    }
 }

--- a/src/main/java/mono/focusider/domain/quiz/dto/info/ChoiceSetInfo.java
+++ b/src/main/java/mono/focusider/domain/quiz/dto/info/ChoiceSetInfo.java
@@ -1,0 +1,7 @@
+package mono.focusider.domain.quiz.dto.info;
+
+public record ChoiceSetInfo(
+        String content,
+        Boolean isAnswer
+) {
+}

--- a/src/main/java/mono/focusider/domain/quiz/dto/info/QuizSetInfo.java
+++ b/src/main/java/mono/focusider/domain/quiz/dto/info/QuizSetInfo.java
@@ -10,6 +10,6 @@ public record QuizSetInfo(
         Integer level,
         CommentaryInfo commentaryInfo,
         List<KeywordType> keywordTypes,
-        List<ChoiceInfo> choiceInfos
+        List<ChoiceSetInfo> choiceSetInfos
 ) {
 }

--- a/src/main/java/mono/focusider/domain/quiz/dto/res/QuizInfo.java
+++ b/src/main/java/mono/focusider/domain/quiz/dto/res/QuizInfo.java
@@ -1,0 +1,24 @@
+package mono.focusider.domain.quiz.dto.res;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import mono.focusider.domain.quiz.domain.Quiz;
+import mono.focusider.domain.quiz.dto.info.ChoiceInfo;
+
+import java.util.List;
+
+@Builder(access = AccessLevel.PRIVATE)
+public record QuizInfo(
+        String title,
+        String content,
+        List<ChoiceInfo> choiceContent
+) {
+    public static QuizInfo of(Quiz quiz, List<ChoiceInfo> choiceInfos) {
+        return QuizInfo
+                .builder()
+                .title(quiz.getTitle())
+                .content(quiz.getContent())
+                .choiceContent(choiceInfos)
+                .build();
+    }
+}

--- a/src/main/java/mono/focusider/domain/quiz/error/QuizErrorCode.java
+++ b/src/main/java/mono/focusider/domain/quiz/error/QuizErrorCode.java
@@ -1,0 +1,16 @@
+package mono.focusider.domain.quiz.error;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import mono.focusider.global.error.code.ErrorCode;
+import org.springframework.http.HttpStatus;
+
+@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
+@Getter
+public enum QuizErrorCode implements ErrorCode {
+    QUIZ_NOT_FOUND(HttpStatus.FORBIDDEN, "퀴즈를 찾을 수 없습니다.");
+
+    private final HttpStatus httpStatus;
+    private final String message;
+}

--- a/src/main/java/mono/focusider/domain/quiz/helper/ChoiceHelper.java
+++ b/src/main/java/mono/focusider/domain/quiz/helper/ChoiceHelper.java
@@ -3,7 +3,7 @@ package mono.focusider.domain.quiz.helper;
 import lombok.RequiredArgsConstructor;
 import mono.focusider.domain.quiz.domain.Choice;
 import mono.focusider.domain.quiz.domain.Quiz;
-import mono.focusider.domain.quiz.dto.info.ChoiceInfo;
+import mono.focusider.domain.quiz.dto.info.ChoiceSetInfo;
 import mono.focusider.domain.quiz.repository.ChoiceRepository;
 import org.springframework.stereotype.Component;
 
@@ -12,7 +12,7 @@ import org.springframework.stereotype.Component;
 public class ChoiceHelper {
     private final ChoiceRepository choiceRepository;
 
-    public void createAndSaveChoice(Quiz quiz, ChoiceInfo choiceInfo) {
-        choiceRepository.save(Choice.of(quiz, choiceInfo.content(), choiceInfo.isAnswer()));
+    public void createAndSaveChoice(Quiz quiz, ChoiceSetInfo choiceSetInfo) {
+        choiceRepository.save(Choice.of(quiz, choiceSetInfo.content(), choiceSetInfo.isAnswer()));
     }
 }

--- a/src/main/java/mono/focusider/domain/quiz/helper/QuizHelper.java
+++ b/src/main/java/mono/focusider/domain/quiz/helper/QuizHelper.java
@@ -3,6 +3,7 @@ package mono.focusider.domain.quiz.helper;
 import lombok.RequiredArgsConstructor;
 import mono.focusider.domain.quiz.domain.Commentary;
 import mono.focusider.domain.quiz.domain.Quiz;
+import mono.focusider.domain.quiz.dto.res.QuizInfo;
 import mono.focusider.domain.quiz.repository.QuizRepository;
 import org.springframework.stereotype.Component;
 
@@ -13,5 +14,9 @@ public class QuizHelper {
 
     public Quiz createAndSaveQuiz(String title, String content, Integer level, Commentary commentary) {
         return quizRepository.save(Quiz.of(title, content, level, commentary));
+    }
+
+    public QuizInfo findQuizInfoByLevelAndMemberId(int level, Long memberId) {
+        return quizRepository.findByLevelAndMemberId(level, memberId);
     }
 }

--- a/src/main/java/mono/focusider/domain/quiz/mapper/ChoiceMapper.java
+++ b/src/main/java/mono/focusider/domain/quiz/mapper/ChoiceMapper.java
@@ -1,0 +1,8 @@
+package mono.focusider.domain.quiz.mapper;
+
+import org.springframework.stereotype.Component;
+
+@Component
+public class ChoiceMapper {
+
+}

--- a/src/main/java/mono/focusider/domain/quiz/mapper/QuizMapper.java
+++ b/src/main/java/mono/focusider/domain/quiz/mapper/QuizMapper.java
@@ -1,0 +1,8 @@
+package mono.focusider.domain.quiz.mapper;
+
+import org.springframework.stereotype.Component;
+
+@Component
+public class QuizMapper {
+
+}

--- a/src/main/java/mono/focusider/domain/quiz/repository/QuizQueryRepository.java
+++ b/src/main/java/mono/focusider/domain/quiz/repository/QuizQueryRepository.java
@@ -1,0 +1,7 @@
+package mono.focusider.domain.quiz.repository;
+
+import mono.focusider.domain.quiz.dto.res.QuizInfo;
+
+public interface QuizQueryRepository {
+    QuizInfo findByLevelAndMemberId(int level, long memberId);
+}

--- a/src/main/java/mono/focusider/domain/quiz/repository/QuizQueryRepositoryImpl.java
+++ b/src/main/java/mono/focusider/domain/quiz/repository/QuizQueryRepositoryImpl.java
@@ -1,0 +1,39 @@
+package mono.focusider.domain.quiz.repository;
+
+import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.dsl.Expressions;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import mono.focusider.domain.quiz.dto.info.ChoiceInfo;
+import mono.focusider.domain.quiz.dto.res.QuizInfo;
+
+import static com.querydsl.core.group.GroupBy.groupBy;
+import static com.querydsl.core.group.GroupBy.list;
+import static mono.focusider.domain.quiz.domain.QChoice.choice;
+import static mono.focusider.domain.quiz.domain.QQuiz.quiz;
+import static mono.focusider.domain.quiz.domain.QQuizAttempt.quizAttempt;
+
+@RequiredArgsConstructor
+public class QuizQueryRepositoryImpl implements QuizQueryRepository{
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public QuizInfo findByLevelAndMemberId(int level, long memberId) {
+        return queryFactory
+                .from(quiz)
+                .leftJoin(quiz.choices, choice)
+                .leftJoin(quiz.quizAttempts, quizAttempt)
+                .where(quiz.level.eq(level).and(quizAttempt.isNull().or(quizAttempt.member.id.ne(memberId))))
+                .orderBy(Expressions.numberTemplate(Double.class, "RAND()").asc())
+                .transform(groupBy(quiz.id).as(
+                        Projections.constructor(QuizInfo.class,
+                                quiz.title,
+                                quiz.content,
+                                list(Projections.constructor(ChoiceInfo.class,
+                                        choice.id,
+                                        choice.content
+                                ))
+                        )
+                )).values().stream().findFirst().orElse(null);
+    }
+}

--- a/src/main/java/mono/focusider/domain/quiz/repository/QuizRepository.java
+++ b/src/main/java/mono/focusider/domain/quiz/repository/QuizRepository.java
@@ -3,5 +3,5 @@ package mono.focusider.domain.quiz.repository;
 import mono.focusider.domain.quiz.domain.Quiz;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface QuizRepository extends JpaRepository<Quiz, Long> {
+public interface QuizRepository extends JpaRepository<Quiz, Long>, QuizQueryRepository {
 }

--- a/src/main/java/mono/focusider/domain/quiz/service/QuizService.java
+++ b/src/main/java/mono/focusider/domain/quiz/service/QuizService.java
@@ -5,7 +5,11 @@ import mono.focusider.domain.quiz.domain.Commentary;
 import mono.focusider.domain.quiz.domain.Keyword;
 import mono.focusider.domain.quiz.domain.Quiz;
 import mono.focusider.domain.quiz.dto.info.QuizSetInfo;
+import mono.focusider.domain.quiz.dto.res.QuizInfo;
 import mono.focusider.domain.quiz.helper.*;
+import mono.focusider.domain.quiz.mapper.ChoiceMapper;
+import mono.focusider.domain.quiz.mapper.QuizMapper;
+import mono.focusider.global.aspect.member.MemberInfoParam;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -20,6 +24,12 @@ public class QuizService {
     private final QuizKeywordHelper quizKeywordHelper;
     private final KeywordHelper keywordHelper;
     private final ChoiceHelper choiceHelper;
+    private final ChoiceMapper choiceMapper;
+    private final QuizMapper quizMapper;
+
+    public QuizInfo findQuizByLevel(MemberInfoParam memberInfoParam) {
+        return quizHelper.findQuizInfoByLevelAndMemberId(memberInfoParam.memberLevel(), memberInfoParam.memberId());
+    }
 
     @Transactional
     public void createAndSaveQuiz(QuizSetInfo quizSetInfo) {
@@ -29,7 +39,7 @@ public class QuizService {
         keywords.forEach(keyword -> {
             quizKeywordHelper.createAndSaveQuizKeyword(quiz, keyword);
         });
-        quizSetInfo.choiceInfos().forEach(choiceInfo -> {
+        quizSetInfo.choiceSetInfos().forEach(choiceInfo -> {
             choiceHelper.createAndSaveChoice(quiz, choiceInfo);
         });
     }

--- a/src/main/java/mono/focusider/global/aspect/member/MemberInfoParam.java
+++ b/src/main/java/mono/focusider/global/aspect/member/MemberInfoParam.java
@@ -6,12 +6,14 @@ import lombok.Builder;
 @Builder(access = AccessLevel.PRIVATE)
 public record MemberInfoParam(
         Long memberId,
+        Integer memberLevel,
         String memberRole
 ) {
-    public static MemberInfoParam of(Long memberId, String memberRole) {
+    public static MemberInfoParam of(Long memberId, Integer memberLevel, String memberRole) {
         return MemberInfoParam
                 .builder()
                 .memberId(memberId)
+                .memberLevel(memberLevel)
                 .memberRole(memberRole)
                 .build();
     }

--- a/src/main/java/mono/focusider/global/aspect/member/MemberInfoParamEnum.java
+++ b/src/main/java/mono/focusider/global/aspect/member/MemberInfoParamEnum.java
@@ -8,6 +8,7 @@ import lombok.Getter;
 @Getter
 public enum MemberInfoParamEnum {
     MEMBER_ID("memberId"),
+    MEMBER_LEVEL("memberLevel"),
     MEMBER_ROLE("memberRole");
 
     private final String desc;

--- a/src/main/java/mono/focusider/global/aspect/member/MemberInfoParamHandlerArgumentResolver.java
+++ b/src/main/java/mono/focusider/global/aspect/member/MemberInfoParamHandlerArgumentResolver.java
@@ -5,7 +5,6 @@ import lombok.RequiredArgsConstructor;
 import mono.focusider.global.annotation.MemberInfo;
 import mono.focusider.global.error.code.GlobalErrorCode;
 import mono.focusider.global.error.exception.UnauthorizedException;
-import mono.focusider.global.security.JwtEnum;
 import mono.focusider.global.security.JwtUtil;
 import mono.focusider.global.utils.cookie.CookieUtils;
 import org.springframework.core.MethodParameter;
@@ -16,7 +15,7 @@ import org.springframework.web.context.request.NativeWebRequest;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.method.support.ModelAndViewContainer;
 
-import static mono.focusider.global.security.JwtEnum.*;
+import static mono.focusider.global.security.JwtEnum.ACCESS_TOKEN_NAME;
 
 @RequiredArgsConstructor
 @Component
@@ -37,7 +36,8 @@ public class MemberInfoParamHandlerArgumentResolver implements HandlerMethodArgu
             throw new UnauthorizedException(GlobalErrorCode.INVALID_TOKEN);
         }
         Long memberId = jwtUtil.getMemberId(accessToken);
+        Integer memberLevel = jwtUtil.getMemberLevel(accessToken);
         String memberRole = jwtUtil.getMemberRole(accessToken);
-        return MemberInfoParam.of(memberId, memberRole);
+        return MemberInfoParam.of(memberId, memberLevel, memberRole);
     }
 }

--- a/src/main/java/mono/focusider/global/security/JwtUtil.java
+++ b/src/main/java/mono/focusider/global/security/JwtUtil.java
@@ -50,6 +50,7 @@ public class JwtUtil {
     private String createToken(AuthUserInfo authUserInfo, Long expireTime) {
         return Jwts.builder()
                 .claim("memberId", authUserInfo.memberId())
+                .claim("level", authUserInfo.level())
                 .claim("memberRole", authUserInfo.memberRole())
                 .issuedAt(new Date(System.currentTimeMillis()))
                 .expiration(new Date(System.currentTimeMillis() + expireTime))


### PR DESCRIPTION
- 유저 레벨에 맞는 퀴즈를 출력합니다.
- 이 때 유저가 풀어봤던 문제는 배제하고 출력합니다.
- Quiz Title, Quiz Content, Quiz Choices를 리턴합니다.
- QueryDsl을 사용하여 Projection으로 QuizInfo를 바로 생성하여 효율성을 높였습니다.