### PR TITLE
FB-21-feat 마이 페이지 정보 출력 api

### DIFF
--- a/src/main/java/mono/focusider/application/member/controller/MemberController.java
+++ b/src/main/java/mono/focusider/application/member/controller/MemberController.java
@@ -1,18 +1,21 @@
 package mono.focusider.application.member.controller;
 
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import mono.focusider.domain.member.dto.req.MemberCategorySaveReqDto;
+import mono.focusider.domain.member.dto.req.MemberInfoReqDto;
 import mono.focusider.domain.member.service.MemberService;
+import mono.focusider.global.annotation.MemberInfo;
+import mono.focusider.global.aspect.member.MemberInfoParam;
 import mono.focusider.global.domain.SuccessResponse;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+
 @Slf4j
 @RestController
 @RequestMapping("/api/member")
@@ -29,5 +32,15 @@ public class MemberController {
     public ResponseEntity<SuccessResponse<?>> add(@RequestBody MemberCategorySaveReqDto req) {
         memberService.createMemberCategory(req);
         return SuccessResponse.ok(null);
+    }
+
+    @Operation(summary = "내 정보 확인", description = "마이 페이지 필요 정보", responses = {
+            @ApiResponse(responseCode = "200",  content = @Content(schema = @Schema(implementation = MemberInfoReqDto.class))),
+            @ApiResponse(responseCode = "500", description = "에러")
+    })
+    @GetMapping
+    public ResponseEntity<SuccessResponse<?>> getMemberInfo(@MemberInfo MemberInfoParam memberInfoParam) {
+        MemberInfoReqDto result = memberService.findMemberInfo(memberInfoParam);
+        return SuccessResponse.ok(result);
     }
 }

--- a/src/main/java/mono/focusider/domain/member/dto/req/MemberInfoReqDto.java
+++ b/src/main/java/mono/focusider/domain/member/dto/req/MemberInfoReqDto.java
@@ -1,0 +1,15 @@
+package mono.focusider.domain.member.dto.req;
+
+import mono.focusider.domain.member.type.MemberGenderType;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+public record MemberInfoReqDto(
+        String profileImageUrl,
+        String accountId,
+        LocalDate birthDay,
+        MemberGenderType memberGenderType,
+        LocalDateTime createdAt
+) {
+}

--- a/src/main/java/mono/focusider/domain/member/helper/MemberHelper.java
+++ b/src/main/java/mono/focusider/domain/member/helper/MemberHelper.java
@@ -2,6 +2,7 @@ package mono.focusider.domain.member.helper;
 
 import lombok.RequiredArgsConstructor;
 import mono.focusider.domain.member.domain.Member;
+import mono.focusider.domain.member.dto.req.MemberInfoReqDto;
 import mono.focusider.domain.member.error.MemberErrorCode;
 import mono.focusider.domain.member.repository.MemberRepository;
 import mono.focusider.global.error.exception.EntityNotFoundException;
@@ -21,6 +22,11 @@ public class MemberHelper {
 
     public Member findMemberByIdOrThrow(Long id) {
         return memberRepository.findById(id)
+                .orElseThrow(() -> new EntityNotFoundException(MemberErrorCode.MEMBER_NOT_FOUND));
+    }
+
+    public MemberInfoReqDto findMemberInfoByIdOrThrow(Long memberId) {
+        return memberRepository.findMemberInfoById(memberId)
                 .orElseThrow(() -> new EntityNotFoundException(MemberErrorCode.MEMBER_NOT_FOUND));
     }
 }

--- a/src/main/java/mono/focusider/domain/member/repository/MemberInfoReqQueryRepository.java
+++ b/src/main/java/mono/focusider/domain/member/repository/MemberInfoReqQueryRepository.java
@@ -1,0 +1,9 @@
+package mono.focusider.domain.member.repository;
+
+import mono.focusider.domain.member.dto.req.MemberInfoReqDto;
+
+import java.util.Optional;
+
+public interface MemberInfoReqQueryRepository {
+    Optional<MemberInfoReqDto> findMemberInfoById(Long memberId);
+}

--- a/src/main/java/mono/focusider/domain/member/repository/MemberInfoReqQueryRepositoryImpl.java
+++ b/src/main/java/mono/focusider/domain/member/repository/MemberInfoReqQueryRepositoryImpl.java
@@ -1,0 +1,32 @@
+package mono.focusider.domain.member.repository;
+
+import com.querydsl.core.types.Projections;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import mono.focusider.domain.member.dto.req.MemberInfoReqDto;
+
+import java.util.Optional;
+
+import static mono.focusider.domain.file.domain.QFile.file;
+import static mono.focusider.domain.member.domain.QMember.member;
+
+@RequiredArgsConstructor
+public class MemberInfoReqQueryRepositoryImpl implements MemberInfoReqQueryRepository{
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public Optional<MemberInfoReqDto> findMemberInfoById(Long memberId) {
+        return Optional.ofNullable(queryFactory
+                .select(Projections.constructor(MemberInfoReqDto.class,
+                        file.url,
+                        member.accountId,
+                        member.birthDate,
+                        member.gender,
+                        member.createdAt
+                ))
+                .from(member)
+                .leftJoin(member.profileImageFile, file)
+                .where(member.id.eq(memberId))
+                .fetchOne());
+    }
+}

--- a/src/main/java/mono/focusider/domain/member/repository/MemberRepository.java
+++ b/src/main/java/mono/focusider/domain/member/repository/MemberRepository.java
@@ -5,7 +5,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
 
-public interface MemberRepository extends JpaRepository<Member, Long> {
+public interface MemberRepository extends JpaRepository<Member, Long>, MemberInfoReqQueryRepository {
 
     Optional<Member> findByAccountId(String accountId);
     boolean existsByAccountId(String accountId);

--- a/src/main/java/mono/focusider/domain/member/service/MemberService.java
+++ b/src/main/java/mono/focusider/domain/member/service/MemberService.java
@@ -7,9 +7,11 @@ import mono.focusider.domain.category.helper.CategoryHelper;
 import mono.focusider.domain.category.mapper.MemberCategoryMapper;
 import mono.focusider.domain.member.domain.Member;
 import mono.focusider.domain.member.dto.req.MemberCategorySaveReqDto;
+import mono.focusider.domain.member.dto.req.MemberInfoReqDto;
 import mono.focusider.domain.member.helper.MemberHelper;
 import mono.focusider.domain.member.type.ReadingHardType;
 import mono.focusider.domain.member.type.ReadingTermType;
+import mono.focusider.global.aspect.member.MemberInfoParam;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -34,6 +36,10 @@ public class MemberService {
             member.addMemberCategory(memberCategoryMapper.toMemberCategory(member, category));
         });
         member.updateMemberLevel(level);
+    }
+
+    public MemberInfoReqDto findMemberInfo(MemberInfoParam memberInfoParam) {
+        return memberHelper.findMemberInfoByIdOrThrow(memberInfoParam.memberId());
     }
 
     private Integer settingLevel(MemberCategorySaveReqDto memberCategorySaveReqDto) {


### PR DESCRIPTION
- 마이 페이지 정보 출력 API 입니다.
{
    "status": 200,
    "message": "요청이 성공했습니다.",
    "data": {
        "profileImageUrl": "https://focusider.s3.ap-northeast-2.amazonaws.com/member_profile_image/25b712942f394a90a8c027f5cef19e62-KakaoTalk_Photo_2024-06-25-14-05-18_001.jpeg",
        "accountId": "gachon123",
        "birthDay": "1999-09-18",
        "memberGenderType": "MALE",
        "createdAt": "2024-08-22T18:56:00.719524"
    }
}
해당 형식으로 출력됩니다.

### ✅ 연관 이슈

- [FB-21]

[FB-21]: https://gachonmono.atlassian.net/browse/FB-21?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ