### PR TITLE
FB-24-feat 로그아웃 api

### DIFF
--- a/src/main/java/mono/focusider/application/auth/controller/AuthController.java
+++ b/src/main/java/mono/focusider/application/auth/controller/AuthController.java
@@ -3,6 +3,7 @@ package mono.focusider.application.auth.controller;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -15,10 +16,7 @@ import mono.focusider.domain.auth.service.AuthService;
 import mono.focusider.global.domain.SuccessResponse;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @Slf4j
 @RestController
@@ -56,6 +54,16 @@ public class AuthController {
         public ResponseEntity<SuccessResponse<?>> checkDuplicatedAccountId(@RequestBody CheckDuplicatedReqDto reqDto) {
                 CheckDuplicatedResDto result = authService.checkDuplicated(reqDto);
                 return SuccessResponse.ok(result);
+        }
+
+        @Operation(summary = "로그 아웃", description = "로그 아웃", responses = {
+                @ApiResponse(responseCode = "200", description = "로그 아웃"),
+                @ApiResponse(responseCode = "500", description = "에러")
+        })
+        @GetMapping("/logout")
+        public ResponseEntity<SuccessResponse<?>> logout(HttpServletRequest request, HttpServletResponse response) {
+                authService.logout(request, response);
+                return SuccessResponse.ok(null);
         }
 
 //        @Operation(summary = "Refresh access token", description = "Use a refresh token to obtain a new access token", responses = {

--- a/src/main/java/mono/focusider/domain/auth/service/AuthService.java
+++ b/src/main/java/mono/focusider/domain/auth/service/AuthService.java
@@ -1,5 +1,6 @@
 package mono.focusider.domain.auth.service;
 
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -16,9 +17,13 @@ import mono.focusider.domain.file.helper.FileHelper;
 import mono.focusider.domain.member.domain.Member;
 import mono.focusider.domain.member.helper.MemberHelper;
 import mono.focusider.global.security.JwtUtil;
+import mono.focusider.global.utils.cookie.CookieUtils;
+import mono.focusider.global.utils.redis.RedisUtils;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import static mono.focusider.global.utils.cookie.CookieEnum.ACCESS_TOKEN;
 
 @Slf4j
 @Service
@@ -32,6 +37,7 @@ public class AuthService {
     private final JwtUtil jwtUtil;
     private final AuthHelper authHelper;
     private final AuthMapper authMapper;
+    private final RedisUtils redisUtils;
 
     @Transactional
     public void signup(SignupReqDto signupReqDto) {
@@ -55,5 +61,10 @@ public class AuthService {
     public CheckDuplicatedResDto checkDuplicated(CheckDuplicatedReqDto checkDuplicatedReqDto) {
         boolean check = authValidator.checkAccountIdWithBoolean(checkDuplicatedReqDto.accountId());
         return authMapper.toCheckDuplicatedResDto(check);
+    }
+
+    public void logout(HttpServletRequest request, HttpServletResponse response) {
+        String accessToken = CookieUtils.getCookieValueWithNameAndKill(request, response, ACCESS_TOKEN.getName());
+        redisUtils.deleteData(accessToken);
     }
 }

--- a/src/main/java/mono/focusider/global/security/JwtFilter.java
+++ b/src/main/java/mono/focusider/global/security/JwtFilter.java
@@ -9,6 +9,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import mono.focusider.domain.auth.dto.info.AuthUserInfo;
 import mono.focusider.domain.auth.mapper.AuthMapper;
+import mono.focusider.domain.member.type.MemberGenderType;
 import mono.focusider.domain.member.type.MemberRole;
 import mono.focusider.global.error.code.GlobalErrorCode;
 import mono.focusider.global.error.exception.ForbiddenException;

--- a/src/main/java/mono/focusider/global/utils/cookie/CookieUtils.java
+++ b/src/main/java/mono/focusider/global/utils/cookie/CookieUtils.java
@@ -30,6 +30,28 @@ public class CookieUtils {
         return null;
     }
 
+    public static String getCookieValueWithNameAndKill(HttpServletRequest request, HttpServletResponse response, String name) {
+        Cookie[] cookies = getCookies(request);
+        try{
+            for (Cookie cookie : cookies) {
+                if (cookie.getName().equals(name)) {
+                    String cookieValue = cookie.getValue();
+                    killCookie(cookie, response);
+                    return cookieValue;
+                }
+            }
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+        return null;
+    }
+
+    public static void killCookie(Cookie cookie, HttpServletResponse response) {
+        cookie.setPath("/");
+        cookie.setMaxAge(0);
+        response.addCookie(cookie);
+    }
+
     public static void addCookie(HttpServletResponse response, Cookie cookie) {
         cookie.setPath("/");
         cookie.setHttpOnly(true);


### PR DESCRIPTION
- 로그아웃 api입니다.
- AccessToken이 담긴 쿠키를 찾고 value를 꺼낸 후 삭제합니다.
- AccessToken 값에 대한 Redis 값을 제거합니다.

### ✅ 연관 이슈

- [FB-24]

[FB-24]: https://gachonmono.atlassian.net/browse/FB-24?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ