### PR TITLE
FB-23-feat 회원 탈퇴 API

### DIFF
--- a/src/main/generated/mono/focusider/domain/member/domain/QMember.java
+++ b/src/main/generated/mono/focusider/domain/member/domain/QMember.java
@@ -33,6 +33,8 @@ public class QMember extends EntityPathBase<Member> {
     //inherited
     public final DateTimePath<java.time.LocalDateTime> createdAt = _super.createdAt;
 
+    public final BooleanPath deleted = createBoolean("deleted");
+
     public final EnumPath<mono.focusider.domain.member.type.MemberGenderType> gender = createEnum("gender", mono.focusider.domain.member.type.MemberGenderType.class);
 
     public final NumberPath<Long> id = createNumber("id", Long.class);

--- a/src/main/java/mono/focusider/application/member/controller/MemberController.java
+++ b/src/main/java/mono/focusider/application/member/controller/MemberController.java
@@ -54,4 +54,14 @@ public class MemberController {
         MemberInfoReqDto result = memberService.findMemberInfo(memberInfoParam);
         return SuccessResponse.ok(result);
     }
+
+    @Operation(summary = "회원 탈퇴", description = "회원 탈퇴", responses = {
+            @ApiResponse(responseCode = "200",  description = "삭제 완료"),
+            @ApiResponse(responseCode = "500", description = "에러")
+    })
+    @DeleteMapping
+    public ResponseEntity<SuccessResponse<?>> deleteMember(@MemberInfo MemberInfoParam memberInfoParam) {
+        memberService.deleteMember(memberInfoParam);
+        return SuccessResponse.ok(null);
+    }
 }

--- a/src/main/java/mono/focusider/domain/member/domain/Member.java
+++ b/src/main/java/mono/focusider/domain/member/domain/Member.java
@@ -87,4 +87,8 @@ public class Member extends BaseTimeEntity {
         this.profileImageFile = profileImageFile;
         this.name = name;
     }
+
+    public void deleteMemberSoft() {
+        this.deleted = true;
+    }
 }

--- a/src/main/java/mono/focusider/domain/member/domain/Member.java
+++ b/src/main/java/mono/focusider/domain/member/domain/Member.java
@@ -11,6 +11,7 @@ import mono.focusider.domain.member.type.MemberRole;
 import mono.focusider.domain.member.type.converter.MemberGenderTypeConverter;
 import mono.focusider.domain.member.type.converter.MemberRoleConverter;
 import mono.focusider.global.domain.BaseTimeEntity;
+import org.hibernate.type.YesNoConverter;
 
 import java.time.LocalDate;
 import java.util.ArrayList;
@@ -46,6 +47,11 @@ public class Member extends BaseTimeEntity {
     @Column(name = "member_role", nullable = false)
     @Convert(converter = MemberRoleConverter.class)
     private MemberRole memberRole;
+
+    @Column(name = "deleted_YN", nullable = false)
+    @Convert(converter = YesNoConverter.class)
+    @Builder.Default
+    private Boolean deleted = Boolean.FALSE;
 
     @OneToMany(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
     @Builder.Default

--- a/src/main/java/mono/focusider/domain/member/error/MemberErrorCode.java
+++ b/src/main/java/mono/focusider/domain/member/error/MemberErrorCode.java
@@ -9,7 +9,8 @@ import org.springframework.http.HttpStatus;
 @RequiredArgsConstructor(access = AccessLevel.PRIVATE)
 @Getter
 public enum MemberErrorCode implements ErrorCode {
-    MEMBER_NOT_FOUND(HttpStatus.FORBIDDEN, "사용자를 찾을 수 없습니다.");
+    MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "사용자를 찾을 수 없습니다."),
+    MEMBER_NOT_DELETED(HttpStatus.FORBIDDEN, "탈퇴하지 않은 사용자 입니다.");
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/main/java/mono/focusider/domain/member/helper/MemberHelper.java
+++ b/src/main/java/mono/focusider/domain/member/helper/MemberHelper.java
@@ -35,7 +35,7 @@ public class MemberHelper {
                 .orElseThrow(() -> new EntityNotFoundException(MemberErrorCode.MEMBER_NOT_FOUND));
     }
 
-    public void deleteMember(Member member) {
+    public void deleteMemberHard(Member member) {
         memberRepository.delete(member);
     }
 }

--- a/src/main/java/mono/focusider/domain/member/helper/MemberHelper.java
+++ b/src/main/java/mono/focusider/domain/member/helper/MemberHelper.java
@@ -34,4 +34,8 @@ public class MemberHelper {
         return memberRepository.findByIdWithFile(id)
                 .orElseThrow(() -> new EntityNotFoundException(MemberErrorCode.MEMBER_NOT_FOUND));
     }
+
+    public void deleteMember(Member member) {
+        memberRepository.delete(member);
+    }
 }

--- a/src/main/java/mono/focusider/domain/member/redis/listener/MemberExpiredListener.java
+++ b/src/main/java/mono/focusider/domain/member/redis/listener/MemberExpiredListener.java
@@ -1,0 +1,26 @@
+package mono.focusider.domain.member.redis.listener;
+
+import mono.focusider.domain.member.redis.service.MemberExpiredService;
+import mono.focusider.global.utils.redis.RedisExpiredListener;
+import org.springframework.data.redis.listener.RedisMessageListenerContainer;
+import org.springframework.stereotype.Component;
+
+import static mono.focusider.global.utils.redis.RedisExpiredDataType.MEMBER_HARD_DELETE;
+
+@Component
+public class MemberExpiredListener extends RedisExpiredListener {
+    private final MemberExpiredService memberExpiredService;
+
+    public MemberExpiredListener(RedisMessageListenerContainer listenerContainer, MemberExpiredService memberExpiredService) {
+        super(listenerContainer);
+        this.memberExpiredService = memberExpiredService;
+    }
+
+    @Override
+    protected void handleExpiredKey(String expiredKey) {
+        if(expiredKey.startsWith("member_deleted:")) {
+            Long memberId = Long.parseLong(expiredKey.substring(MEMBER_HARD_DELETE.getPrefix().length()));
+            memberExpiredService.execute(memberId);
+        }
+    }
+}

--- a/src/main/java/mono/focusider/domain/member/redis/service/MemberExpiredService.java
+++ b/src/main/java/mono/focusider/domain/member/redis/service/MemberExpiredService.java
@@ -3,6 +3,7 @@ package mono.focusider.domain.member.redis.service;
 import lombok.RequiredArgsConstructor;
 import mono.focusider.domain.member.domain.Member;
 import mono.focusider.domain.member.helper.MemberHelper;
+import mono.focusider.domain.member.validate.MemberValidate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -11,9 +12,11 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional
 public class MemberExpiredService {
     private final MemberHelper memberHelper;
+    private final MemberValidate memberValidate;
 
     public void execute(Long memberId) {
         Member member = memberHelper.findMemberByIdOrThrow(memberId);
-        memberHelper.deleteMember(member);
+        memberValidate.validateDeletedMember(member);
+        memberHelper.deleteMemberHard(member);
     }
 }

--- a/src/main/java/mono/focusider/domain/member/redis/service/MemberExpiredService.java
+++ b/src/main/java/mono/focusider/domain/member/redis/service/MemberExpiredService.java
@@ -1,0 +1,19 @@
+package mono.focusider.domain.member.redis.service;
+
+import lombok.RequiredArgsConstructor;
+import mono.focusider.domain.member.domain.Member;
+import mono.focusider.domain.member.helper.MemberHelper;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service("MEMBER_DELETED_EXPIRED")
+@RequiredArgsConstructor
+@Transactional
+public class MemberExpiredService {
+    private final MemberHelper memberHelper;
+
+    public void execute(Long memberId) {
+        Member member = memberHelper.findMemberByIdOrThrow(memberId);
+        memberHelper.deleteMember(member);
+    }
+}

--- a/src/main/java/mono/focusider/domain/member/validate/MemberValidate.java
+++ b/src/main/java/mono/focusider/domain/member/validate/MemberValidate.java
@@ -1,0 +1,17 @@
+package mono.focusider.domain.member.validate;
+
+import mono.focusider.domain.member.domain.Member;
+import mono.focusider.global.error.exception.BusinessException;
+import org.springframework.stereotype.Component;
+
+import static mono.focusider.domain.member.error.MemberErrorCode.MEMBER_NOT_DELETED;
+
+@Component
+public class MemberValidate {
+
+    public void validateDeletedMember(Member member) {
+        if(!member.getDeleted()) {
+            throw new BusinessException(MEMBER_NOT_DELETED);
+        }
+    }
+}

--- a/src/main/java/mono/focusider/global/utils/redis/RedisExpiredData.java
+++ b/src/main/java/mono/focusider/global/utils/redis/RedisExpiredData.java
@@ -6,7 +6,7 @@ import lombok.Builder;
 import java.time.Duration;
 import java.time.LocalDate;
 
-import static mono.focusider.global.utils.redis.RedisExpiredDataType.*;
+import static mono.focusider.global.utils.redis.RedisExpiredDataType.MEMBER_HARD_DELETE;
 
 
 @Builder(access = AccessLevel.PRIVATE)
@@ -23,6 +23,14 @@ public record RedisExpiredData(
                 .build();
     }
 
+    public static RedisExpiredData ofMemberHardDeleted(Long memberId) {
+        return RedisExpiredData
+                .builder()
+                .key(MEMBER_HARD_DELETE.getPrefix() + memberId)
+                .defaultValue(MEMBER_HARD_DELETE.getDefaultValue())
+                .expiredTime(MEMBER_HARD_DELETE.getDeadLine())
+                .build();
+    }
 
     private static Long calcExpiredTime(LocalDate expiredDate) {
         LocalDate now = LocalDate.now();

--- a/src/main/java/mono/focusider/global/utils/redis/RedisExpiredDataType.java
+++ b/src/main/java/mono/focusider/global/utils/redis/RedisExpiredDataType.java
@@ -7,11 +7,7 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor(access = AccessLevel.PRIVATE)
 @Getter
 public enum RedisExpiredDataType {
-    RAFFLE_WAIT_MEMBER_EXPIRED("raffle_wait_member:", "1", 86400000L),
-    RAFFLE_WIN_MEMBER_EXPIRED("raffle_win_member:", "3", 259200000L),
-    EMAIL_RECEIVED_MEMBER("certification:", null, 300000L),
-    PENALTY_RECEIVED_MEMBER("penalty:", null, 300000L),
-    WKT_END_EXPIRED("wkt_end_date:", null, null);
+    MEMBER_HARD_DELETE("member_deleted:", "1", 1209600000L);
 
     private final String prefix;
     private final String defaultValue;

--- a/src/main/java/mono/focusider/global/utils/redis/RedisExpiredDataType.java
+++ b/src/main/java/mono/focusider/global/utils/redis/RedisExpiredDataType.java
@@ -7,7 +7,7 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor(access = AccessLevel.PRIVATE)
 @Getter
 public enum RedisExpiredDataType {
-    MEMBER_HARD_DELETE("member_deleted:", "1", 1209600000L);
+    MEMBER_HARD_DELETE("member_deleted:", "deleted", 1209600000L);
 
     private final String prefix;
     private final String defaultValue;

--- a/src/main/java/mono/focusider/global/utils/redis/RedisExpiredListener.java
+++ b/src/main/java/mono/focusider/global/utils/redis/RedisExpiredListener.java
@@ -1,21 +1,21 @@
-//package mono.focusider.global.utils.redis;
-//
-//import org.springframework.data.redis.connection.Message;
-//import org.springframework.data.redis.listener.KeyExpirationEventMessageListener;
-//import org.springframework.data.redis.listener.RedisMessageListenerContainer;
-//import org.springframework.stereotype.Component;
-//
-//@Component
-//public abstract class RedisExpiredListener extends KeyExpirationEventMessageListener {
-//    public RedisExpiredListener(RedisMessageListenerContainer listenerContainer) {
-//        super(listenerContainer);
-//    }
-//
-//    @Override
-//    public void onMessage(Message message, byte[] pattern) {
-//        String expiredKey = message.toString();
-//        handleExpiredKey(expiredKey);
-//    }
-//
-//    protected abstract void handleExpiredKey(String expiredKey);
-//}
+package mono.focusider.global.utils.redis;
+
+import org.springframework.data.redis.connection.Message;
+import org.springframework.data.redis.listener.KeyExpirationEventMessageListener;
+import org.springframework.data.redis.listener.RedisMessageListenerContainer;
+import org.springframework.stereotype.Component;
+
+@Component
+public abstract class RedisExpiredListener extends KeyExpirationEventMessageListener {
+    public RedisExpiredListener(RedisMessageListenerContainer listenerContainer) {
+        super(listenerContainer);
+    }
+
+    @Override
+    public void onMessage(Message message, byte[] pattern) {
+        String expiredKey = message.toString();
+        handleExpiredKey(expiredKey);
+    }
+
+    protected abstract void handleExpiredKey(String expiredKey);
+}


### PR DESCRIPTION
- 회원 탈퇴 API 입니다.
- Soft Delete로 delete_yn 칼럼을 Y로 바꿉니다.
- Redis에 "member:deleted:{memberId}" Key 값으로 2주일 기한을 둡니다.
- 기한이 지났을 때 RedisExpiredListener를 통해서 member 삭제 로직을 발생시키고 Member의 delete_yn이 Y라면 Hard Delete를 진행합니다.

### ✅ 연관 이슈

- [FB-23]

[FB-23]: https://gachonmono.atlassian.net/browse/FB-23?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ