### PR TITLE
FB-31-refactor 회원 가입 시 JWT 토큰 바로 제공 및 퀴즈, 아티클 랜덤 출력시 level +-1로 변경

### DIFF
--- a/src/main/java/mono/focusider/application/auth/controller/AuthController.java
+++ b/src/main/java/mono/focusider/application/auth/controller/AuthController.java
@@ -31,8 +31,9 @@ public class AuthController {
                         @ApiResponse(responseCode = "400", description = "Bad request - Invalid input")
         })
         @PostMapping(value = "/signup", consumes = MediaType.APPLICATION_JSON_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
-        public ResponseEntity<SuccessResponse<?>> signup(@Valid @RequestBody SignupReqDto requestDto) {
-                authService.signup(requestDto);
+        public ResponseEntity<SuccessResponse<?>> signup(@Valid @RequestBody SignupReqDto requestDto,
+                                                         HttpServletResponse response) {
+                authService.signup(requestDto, response);
                 return SuccessResponse.ok(null);
         }
 

--- a/src/main/java/mono/focusider/domain/article/repository/ArticleDetailDtoQueryRepositoryImpl.java
+++ b/src/main/java/mono/focusider/domain/article/repository/ArticleDetailDtoQueryRepositoryImpl.java
@@ -28,7 +28,8 @@ public class ArticleDetailDtoQueryRepositoryImpl implements ArticleDetailDtoQuer
                                                 article.categoryType))
                                 .from(article)
                                 .leftJoin(article.reading, reading)
-                                .where(article.categoryType.in(categoryTypes).and(article.level.eq(member.getLevel()))
+                                .where(article.categoryType.in(categoryTypes)
+                                        .and(article.level.between(member.getLevel() - 1, member.getLevel() + 1))
                                                 .and(reading.isNull().or(reading.member.id.ne(member.getId()))))
                                 .orderBy(Expressions.numberTemplate(Double.class, "RAND()").asc())
                                 .fetchFirst();

--- a/src/main/java/mono/focusider/domain/auth/helper/AuthHelper.java
+++ b/src/main/java/mono/focusider/domain/auth/helper/AuthHelper.java
@@ -13,7 +13,7 @@ public class AuthHelper {
 
     private final MemberRepository memberRepository;
 
-    public void createMemberAndSave(SignupReqDto signupReqDto, File profileImageFile, String password) {
-        memberRepository.save(Member.createMember(signupReqDto, profileImageFile, password));
+    public Member createMemberAndSave(SignupReqDto signupReqDto, File profileImageFile, String password) {
+        return memberRepository.save(Member.createMember(signupReqDto, profileImageFile, password));
     }
 }

--- a/src/main/java/mono/focusider/domain/member/repository/MemberQueryRepositoryImpl.java
+++ b/src/main/java/mono/focusider/domain/member/repository/MemberQueryRepositoryImpl.java
@@ -6,6 +6,7 @@ import mono.focusider.domain.member.domain.Member;
 
 import java.util.Optional;
 
+import static mono.focusider.domain.category.domain.QMemberCategory.memberCategory;
 import static mono.focusider.domain.file.domain.QFile.file;
 import static mono.focusider.domain.member.domain.QMember.member;
 
@@ -26,7 +27,8 @@ public class MemberQueryRepositoryImpl implements MemberQueryRepository{
     public Optional<Member> findByIdWithCategories(Long memberId) {
         return Optional.ofNullable(queryFactory
                 .selectFrom(member)
-                .leftJoin(member.memberCategories).fetchJoin()
+                .leftJoin(member.memberCategories, memberCategory).fetchJoin()
+                .leftJoin(memberCategory.category).fetchJoin()
                 .where(member.id.eq(memberId))
                 .fetchOne()
         );

--- a/src/main/java/mono/focusider/domain/quiz/repository/quiz/QuizGetResDtoQueryRepositoryImpl.java
+++ b/src/main/java/mono/focusider/domain/quiz/repository/quiz/QuizGetResDtoQueryRepositoryImpl.java
@@ -23,7 +23,7 @@ public class QuizGetResDtoQueryRepositoryImpl implements QuizGetResDtoQueryRepos
                 .from(quiz)
                 .leftJoin(quiz.choices, choice)
                 .leftJoin(quiz.quizAttempts, quizAttempt)
-                .where(quiz.level.eq(level).and(quizAttempt.isNull().or(quizAttempt.member.id.ne(memberId))))
+                .where(quiz.level.between(level - 1, level + 1).and(quizAttempt.isNull().or(quizAttempt.member.id.ne(memberId))))
                 .orderBy(Expressions.numberTemplate(Double.class, "RAND()").asc())
                 .transform(groupBy(quiz.id).as(
                         Projections.constructor(QuizGetResDto.class,

--- a/src/main/java/mono/focusider/global/config/security/SecurityConfig.java
+++ b/src/main/java/mono/focusider/global/config/security/SecurityConfig.java
@@ -27,7 +27,8 @@ public class SecurityConfig {
     private final AuthMapper authMapper;
     private final RedisUtils redisUtils;
 
-    private static final String[] whiteList = { "/api/auth/login", "/api/auth/signup", "/api/member/add", "/api/file",
+    private static final String[] whiteList = { "/api/auth/login", "/api/auth/signup", "/api/auth/duplicated",
+            "/api/member/add", "/api/file",
             "/api/quiz/make", "/v3/**", "/swagger-ui/**", "/.well-known/acme-challenge/*" };
 
     @Bean


### PR DESCRIPTION
---
name: feature
about: Suggest an idea for this project
title: '[feat] #[issue number] [issue name]'
labels: ''
assignees: ''
---

## 1. 추가사항 혹은 변경사항
회원 가입 성공 시 JWT를 바로 발급하여 쿠키에 저장합니다.
아티클, 퀴즈 랜덤 출력시 eq(level) -> between(level - 1, level + 1)로 변경하여 조금 더 다양한 폭에서 뽑아낼 수 있도록 수정했습니다.
<br>

## 2. 상세 설명 (이미지 포함)

<br>

## 3. 필요한 내용
